### PR TITLE
Fix use client directive in ThemeToggle

### DIFF
--- a/src/app/Components/Theme/ThemeToggle.tsx
+++ b/src/app/Components/Theme/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-'use clien';
+'use client';
 import React, { useEffect } from 'react';
 import LightMode from '../../assets/image/light-mode.svg';
 import DarkMode from '../../assets/image/dark-mode.svg';


### PR DESCRIPTION
## Summary
- fix incorrect `'use client'` directive in ThemeToggle component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866477c5084832a9c7a83ca349e6604